### PR TITLE
added a forward slash while copying ssh pub key's command to authorized keys

### DIFF
--- a/prod/fabfile.py
+++ b/prod/fabfile.py
@@ -41,7 +41,7 @@ env.ssh_key_dir = '~/fsp-deployment-guide/ssh_keys'
 def bootstrap():
     env.ssh_key_filepath = os.path.join(env.ssh_key_dir, env.host_string + "_prod_key")
     local('ssh-keygen -t rsa -b 2048 -f {}'.format(env.ssh_key_filepath))
-    local('cp {} {}authorized_keys'.format(env.ssh_key_filepath + ".pub", env.ssh_key_dir))
+    local('cp {} {}/authorized_keys'.format(env.ssh_key_filepath + ".pub", env.ssh_key_dir))
 
     sed('/etc/ssh/sshd_config', '^UsePAM yes', 'UsePAM no')
     sed('/etc/ssh/sshd_config', '^PermitRootLogin yes', 'PermitRootLogin no')


### PR DESCRIPTION
I was trying to provision a server and figured out the command to copy the pub key's content to authorized keys was not working properly due to missing forward slash.
Hope, I make sense.

Thanks.
